### PR TITLE
delete fuzzy

### DIFF
--- a/src/locales/id.po
+++ b/src/locales/id.po
@@ -3746,7 +3746,6 @@ msgctxt "Customer.io email: Unknown Login (Deriv) "
 msgid "Security alert: New sign-in activity"
 msgstr "Peringatan keamanan: Aktivitas pengaksesan terbaru"
 
-#, fuzzy
 #| msgctxt "Customer.io email: IDV POI Verification rejected "
 #| msgid "Security and privacy"
 msgid "Security and privacy"


### PR DESCRIPTION
The fuzzy comment will prevent the string from getting translated
we will investigate how this flow works but a test is failing preventing from release so we will remove the comment for now and proceed